### PR TITLE
Ignoring case when transforming absolute paths to relative ones

### DIFF
--- a/dropbox-api
+++ b/dropbox-api
@@ -8,7 +8,7 @@ use DateTime::Format::Strptime;
 use Encode;
 use Encode::Locale;
 use File::Basename qw(dirname basename);
-use File::Spec::Functions qw(abs2rel catfile);
+use File::Spec::Functions qw(catfile);
 use File::Temp;
 use Getopt::Std;
 use JSON;
@@ -336,6 +336,13 @@ sub help {
     $help=~s|^ {8}||mg;
     $help=~s|^\s*\n||;
     print "\n$help\n";
+}
+
+sub abs2rel {
+    my ($remote, $base) = @_;
+    my $rel_path = $remote;
+    $rel_path =~ s/^$base\/?//i;
+    return $rel_path;
 }
 
 sub setup {


### PR DESCRIPTION
When syncing into a case-sensitive fs, paths and filenames using inconsistent case cause a wrong sync.

Dropbox is a case-insensitive fs, so when you have a primary dropbox managed in a case-insensitive fs (hfs), filenames tend to be stored in whatever original case they were, and protracted file renaming can lead to structures made like this:

```
/Documenti/
/Documenti/.localized
/Documenti/Saves/
/documenti/Saves/2011-12/2.jpg
/documenti/Saves/2011-12/3.jpg
/documenti/Saves/2011-12/2011-12.pdf
/documenti/Saves/2011-12/darker.jpg
```

When syncing into a case-sensitive fs, paths and filenames using inconsistent case cause a wrong sync.

Dropbox is a case-insensitive fs, so when you have a primary dropbox managed in a case-insensitive fs (hfs), filenames tend to be stored in whatever original case they were, and protracted file renaming can lead to structures made like this:

```
/Documenti/
/Documenti/.localized
/Documenti/Saves/
/documenti/Saves/2011-12/2.jpg
/documenti/Saves/2011-12/3.jpg
/documenti/Saves/2011-12/2011-12.pdf
/documenti/Saves/2011-12/darker.jpg
```

These should be treated the same, regardless of case. Unfortunately, a case-sensitive fs breaks this:

```
/store # dropbox-api sync dropbox:/documenti . -n
!! enable dry run !!
download /store/../Documenti/.localized
mkpath /store/../Documenti/Saves
mkpath /store/Saves/2011-12
download /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/3.jpg
...
```

Notice that I synced "documenti", not "Documenti". By extension, when I sync "Documenti" the opposite happens:

```
/store # dropbox-api sync dropbox:/Documenti . -n
!! enable dry run !!
download /store/.localized
mkpath /store/Saves
mkpath /store/../documenti/Saves/2011-12/
download /store/../documenti/Saves/2011-12/2.jpg
download /store/../documenti/Saves/2011-12/3.jpg
download /store/../documenti/Saves/2011-12/2011-12.pdf
download /store/../documenti/Saves/2011-12/darker.jpg
...
```

Here's it again running debug:

```
/store # dropbox-api sync dropbox:/documenti . -Dn
!! enable dry run !!
check: ../Documenti/.localized
remote: 1306241683          0 /Documenti/.localized
local:           -          - /store/../Documenti/.localized
download /store/../Documenti/.localized
check: ../Documenti/Saves
remote: /Documenti/Saves
local:  /store/../Documenti/Saves
mkpath /store/../Documenti/Saves
check: Saves/2011-12
remote: /documenti/Saves/2011-12
local:  /store/Saves/2011-12
mkpath /store/Saves/2011-12
check: Saves/2011-12/2.jpg
remote: 1363357941    1712875 /documenti/Saves/2011-12/2.jpg
local:           -          - /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/2.jpg
check: Saves/2011-12/3.jpg
remote: 1363357941    1532957 /documenti/Saves/2011-12/3.jpg
local:           -          - /store/Saves/2011-12/3.jpg
download /store/Saves/2011-12/3.jpg
...
```

Again, notice the difference in treatment between different case:

```
remote: 1306241683          0 /Documenti/.localized # -> /store/../Documenti/.localized
remote: /documenti/Saves/2011-12 # -> /store/Saves/2011-12
...
```

I've replaced the `abs2rel` from `File::Spec` with an implementation using a case-insensitive regex replace, which while much simpler, should cover all reasonable situations.

```
/store # dropbox-api sync dropbox:/documenti . -n
!! enable dry run !!
download /store/.localized
mkpath /store/Saves
mkpath /store/Saves/2011-12
download /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/3.jpg
download /store/Saves/2011-12/2011-12.pdf
download /store/Saves/2011-12/darker.jpg
...
```

These should be treated the same, regardless of case. Unfortunately, a case-sensitive fs breaks this:

```
/store # dropbox-api sync dropbox:/documenti . -n
!! enable dry run !!
download /store/../Documenti/.localized
mkpath /store/../Documenti/Saves
mkpath /store/Saves/2011-12
download /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/3.jpg
...
```

Notice that I synced "documenti", not "Documenti". By extension, when I sync "Documenti" the opposite happens:

```
/store # dropbox-api sync dropbox:/Documenti . -n
!! enable dry run !!
download /store/.localized
mkpath /store/Saves
mkpath /store/../documenti/Saves/2011-12/
download /store/../documenti/Saves/2011-12/2.jpg
download /store/../documenti/Saves/2011-12/3.jpg
download /store/../documenti/Saves/2011-12/2011-12.pdf
download /store/../documenti/Saves/2011-12/darker.jpg
...
```

Here's the first again running debug:

```
/store # dropbox-api sync dropbox:/documenti . -Dn
!! enable dry run !!
check: ../Documenti/.localized
remote: 1306241683          0 /Documenti/.localized
local:           -          - /store/../Documenti/.localized
download /store/../Documenti/.localized
check: ../Documenti/Saves
remote: /Documenti/Saves
local:  /store/../Documenti/Saves
mkpath /store/../Documenti/Saves
check: Saves/2011-12
remote: /documenti/Saves/2011-12
local:  /store/Saves/2011-12
mkpath /store/Saves/2011-12
check: Saves/2011-12/2.jpg
remote: 1363357941    1712875 /documenti/Saves/2011-12/2.jpg
local:           -          - /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/2.jpg
check: Saves/2011-12/3.jpg
remote: 1363357941    1532957 /documenti/Saves/2011-12/3.jpg
local:           -          - /store/Saves/2011-12/3.jpg
download /store/Saves/2011-12/3.jpg
...
```

Again, notice the difference in treatment between different case:

```
remote: 1306241683          0 /Documenti/.localized # -> /store/../Documenti/.localized
remote: /documenti/Saves/2011-12 # -> /store/Saves/2011-12
...
```

I've replaced the `abs2rel` from `File::Spec` with an implementation using a case-insensitive regex replace, which while much simpler, should cover all reasonable situations.

```
/store # dropbox-api sync dropbox:/documenti . -n
!! enable dry run !!
download /store/.localized
mkpath /store/Saves
mkpath /store/Saves/2011-12
download /store/Saves/2011-12/2.jpg
download /store/Saves/2011-12/3.jpg
download /store/Saves/2011-12/2011-12.pdf
download /store/Saves/2011-12/darker.jpg
...
```
