### PR TITLE
Ignore stty errors when stdin isn't a terminal

### DIFF
--- a/dropbox-api
+++ b/dropbox-api
@@ -99,7 +99,7 @@ my $format = {
 my $cols = 50;
 if ($verbose) {
     eval {
-        my $stty = `stty -a`;
+        my $stty = `stty -a 2>/dev/null`;
         if ($stty =~ m|columns (\d+)| || $stty =~ m|(\d+) columns|) {
             $cols = $1;
         }


### PR DESCRIPTION
Prevents extra output on stderr when running from cron with `-v'.
